### PR TITLE
fix: improve initials generation for party names

### DIFF
--- a/src/components/PartyLogo.tsx
+++ b/src/components/PartyLogo.tsx
@@ -75,12 +75,27 @@ export default function PartyLogo({
   };
 
   // Fallback: use initials from party name
+  const joinWords = new Set([
+    "and",
+    "the",
+    "of",
+    "for",
+    "in",
+    "on",
+    "at",
+    "to",
+    "a",
+    "an",
+  ]);
+
   const initials = name
     ? name
-        .split(" ")
-        .map((s) => s[0])
-        .slice(0, 2)
-        .join("")
+        .split(/\s+/) // Split by whitespace
+        .map((word) => word.replace(/[^a-zA-Z]/g, "")) // Remove special characters
+        .filter((word) => word.length > 0) // Remove empty strings
+        .filter((word) => !joinWords.has(word.toLowerCase())) // Exclude joining words
+        .join("") // Join all words together
+        .slice(0, 2) // Take first two letters
         .toUpperCase()
     : "P";
 


### PR DESCRIPTION
This pull request improves the logic for generating party initials in the `PartyLogo` component by making the output more meaningful and visually consistent. The main change is a more sophisticated approach to extracting initials from party names, which now excludes common joining words and special characters.

Improvements to initials generation:

* Updated the initials logic in `PartyLogo.tsx` to remove special characters and exclude common joining words (like "and", "the", "of", etc.) when generating initials from the party name. The result is now the first two letters of the filtered name, in uppercase.