### PR TITLE
feat: more themes & page cleanup

### DIFF
--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,18 +1,18 @@
 import { useRouter } from "@tanstack/react-router";
-import {  createContext, use } from "react";
-import type {PropsWithChildren} from "react";
-import type {T as Theme} from "@/lib/server/theme";
-import {  setThemeServerFn } from "@/lib/server/theme";
+import { createContext, use } from "react";
+import type { PropsWithChildren } from "react";
+import type { ThemeId } from "@/lib/server/theme";
+import { setThemeServerFn } from "@/lib/server/theme";
 
-type ThemeContextVal = { theme: Theme; setTheme: (val: Theme) => void };
-type Props = PropsWithChildren<{ theme: Theme }>;
+type ThemeContextVal = { theme: ThemeId; setTheme: (val: ThemeId) => void };
+type Props = PropsWithChildren<{ theme: ThemeId }>;
 
 const ThemeContext = createContext<ThemeContextVal | null>(null);
 
 export function ThemeProvider({ children, theme }: Props) {
   const router = useRouter();
 
-  function setTheme(val: Theme) {
+  function setTheme(val: ThemeId) {
     setThemeServerFn({ data: val }).then(() => router.invalidate());
   }
 

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,18 +1,55 @@
-import { Moon, Sun } from "lucide-react";
+import { Check, Palette } from "lucide-react";
+import { useState } from "react";
 import { useTheme } from "@/components/theme-provider";
+import { themes } from "@/lib/server/theme";
+import type { ThemeId } from "@/lib/server/theme";
 import { SidebarMenuButton } from "@/components/ui/sidebar";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
 
 export function ModeToggle() {
   const { theme, setTheme } = useTheme();
-
-  function toggleTheme() {
-    setTheme(theme === "light" ? "dark" : "light");
-  }
+  const [open, setOpen] = useState(false);
 
   return (
-    <SidebarMenuButton onClick={toggleTheme}>
-      {theme === "dark" ? <Moon /> : <Sun />}
-      <span>Change theme</span>
-    </SidebarMenuButton>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <SidebarMenuButton>
+          <Palette />
+          <span className="flex-1">Theme</span>
+        </SidebarMenuButton>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="start" className="w-52 p-1.5">
+        <p className="px-2.5 py-1.5 text-xs font-medium text-muted-foreground">
+          Choose a theme
+        </p>
+        {themes.map((t) => (
+          <button
+            key={t.id}
+            onClick={() => {
+              setTheme(t.id as ThemeId);
+              setOpen(false);
+            }}
+            className={`flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-sm transition-colors hover:bg-accent hover:text-accent-foreground ${
+              theme === t.id
+                ? "bg-accent text-accent-foreground font-medium"
+                : "text-popover-foreground"
+            }`}
+          >
+            <span
+              className="h-4 w-4 shrink-0 rounded-full border border-border/50"
+              style={{ backgroundColor: t.swatch }}
+            />
+            <span className="flex-1 text-left">{t.label}</span>
+            {theme === t.id && (
+              <Check className="h-3.5 w-3.5 shrink-0 text-primary" />
+            )}
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,87 @@
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-1 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+  return (
+    <div
+      data-slot="popover-title"
+      className={cn("font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverAnchor,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverDescription,
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,25 +1,25 @@
-import * as React from "react"
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
-import { Select as SelectPrimitive } from "radix-ui"
+import * as React from "react";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import { Select as SelectPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Select({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Root>) {
-  return <SelectPrimitive.Root data-slot="select" {...props} />
+  return <SelectPrimitive.Root data-slot="select" {...props} />;
 }
 
 function SelectGroup({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Group>) {
-  return <SelectPrimitive.Group data-slot="select-group" {...props} />
+  return <SelectPrimitive.Group data-slot="select-group" {...props} />;
 }
 
 function SelectValue({
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Value>) {
-  return <SelectPrimitive.Value data-slot="select-value" {...props} />
+  return <SelectPrimitive.Value data-slot="select-value" {...props} />;
 }
 
 function SelectTrigger({
@@ -28,15 +28,15 @@ function SelectTrigger({
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
       data-size={size}
       className={cn(
-        "border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        "border-input data-placeholder:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
       )}
       {...props}
     >
@@ -45,7 +45,7 @@ function SelectTrigger({
         <ChevronDownIcon className="size-4 opacity-50" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
@@ -60,10 +60,10 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
-          className
+          className,
         )}
         position={position}
         align={align}
@@ -74,7 +74,7 @@ function SelectContent({
           className={cn(
             "p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1"
+              "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width) scroll-my-1",
           )}
         >
           {children}
@@ -82,7 +82,7 @@ function SelectContent({
         <SelectScrollDownButton />
       </SelectPrimitive.Content>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
 function SelectLabel({
@@ -95,7 +95,7 @@ function SelectLabel({
       className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectItem({
@@ -107,8 +107,8 @@ function SelectItem({
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className,
       )}
       {...props}
     >
@@ -122,7 +122,7 @@ function SelectItem({
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
 function SelectSeparator({
@@ -135,7 +135,7 @@ function SelectSeparator({
       className={cn("bg-border pointer-events-none -mx-1 my-1 h-px", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -147,13 +147,13 @@ function SelectScrollUpButton({
       data-slot="select-scroll-up-button"
       className={cn(
         "flex cursor-default items-center justify-center py-1",
-        className
+        className,
       )}
       {...props}
     >
       <ChevronUpIcon className="size-4" />
     </SelectPrimitive.ScrollUpButton>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -165,13 +165,13 @@ function SelectScrollDownButton({
       data-slot="select-scroll-down-button"
       className={cn(
         "flex cursor-default items-center justify-center py-1",
-        className
+        className,
       )}
       {...props}
     >
       <ChevronDownIcon className="size-4" />
     </SelectPrimitive.ScrollDownButton>
-  )
+  );
 }
 
 export {
@@ -185,4 +185,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-}
+};

--- a/src/lib/server/theme.ts
+++ b/src/lib/server/theme.ts
@@ -2,7 +2,68 @@ import { createServerFn } from "@tanstack/react-start";
 import { getCookie, setCookie } from "@tanstack/react-start/server";
 import * as z from "zod";
 
-const postThemeValidator = z.union([z.literal("light"), z.literal("dark")]);
+export const themes = [
+  {
+    id: "light",
+    label: "Default (Light)",
+    isDark: false,
+    swatch: "oklch(0.55 0.09 145)",
+  },
+  {
+    id: "dark",
+    label: "Default (Dark)",
+    isDark: true,
+    swatch: "oklch(0.58 0.07 150)",
+  },
+  {
+    id: "dracula",
+    label: "Dracula",
+    isDark: true,
+    swatch: "oklch(0.7 0.16 310)",
+  },
+  {
+    id: "rose-pine",
+    label: "Rosé Pine",
+    isDark: true,
+    swatch: "oklch(0.68 0.14 350)",
+  },
+  {
+    id: "catppuccin-dark",
+    label: "Catppuccin",
+    isDark: true,
+    swatch: "oklch(0.7 0.15 310)",
+  },
+  {
+    id: "t3",
+    label: "t3",
+    isDark: true,
+    swatch: "oklch(0.55 0.15 355)",
+  },
+  {
+    id: "nord",
+    label: "Nord",
+    isDark: true,
+    swatch: "oklch(0.68 0.06 240)",
+  },
+  {
+    id: "solarized-light",
+    label: "Solarized (Light)",
+    isDark: false,
+    swatch: "oklch(0.62 0.1 230)",
+  },
+  {
+    id: "solarized",
+    label: "Solarized",
+    isDark: true,
+    swatch: "oklch(0.62 0.1 230)",
+  },
+];
+
+export type ThemeId = (typeof themes)[number]["id"];
+
+const postThemeValidator = z.enum(
+  themes.map((t) => t.id) as [ThemeId, ...ThemeId[]],
+);
 export type T = z.infer<typeof postThemeValidator>;
 const storageKey = "_preferred-theme";
 
@@ -13,3 +74,11 @@ export const getThemeServerFn = createServerFn().handler(
 export const setThemeServerFn = createServerFn({ method: "POST" })
   .inputValidator(postThemeValidator)
   .handler(({ data }) => setCookie(storageKey, data));
+
+export function getThemeClasses(themeId: ThemeId): string {
+  const theme = themes.find((t) => t.id === themeId);
+  if (!theme) return "dark";
+  const classes = [themeId];
+  if (theme.isDark) classes.push("dark");
+  return classes.join(" ");
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -17,7 +17,7 @@ import {
   SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/app-sidebar";
-import { getThemeServerFn } from "@/lib/server/theme";
+import { getThemeServerFn, getThemeClasses } from "@/lib/server/theme";
 import { ThemeProvider } from "@/components/theme-provider";
 import { NotFound } from "@/components/not-found";
 
@@ -89,7 +89,7 @@ function RootLayout() {
 function RootDocument({ children }: { children: React.ReactNode }) {
   const { theme } = Route.useLoaderData();
   return (
-    <html lang="en" className={theme} suppressHydrationWarning>
+    <html lang="en" className={getThemeClasses(theme)} suppressHydrationWarning>
       <head>
         <HeadContent />
       </head>

--- a/src/routes/companies/$id.tsx
+++ b/src/routes/companies/$id.tsx
@@ -4,13 +4,27 @@ import {
   Building2,
   DollarSign,
   Edit,
+  TrendingDown,
   TrendingUp,
   Users,
   Wallet,
 } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import * as LucideIcons from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { getCompanyById, getCompanyStakeholders } from "@/lib/server/stocks";
+import {
+  getCompanyById,
+  getCompanyStakeholders,
+  getSharePriceHistory,
+} from "@/lib/server/stocks";
 import { getCurrentUserInfo } from "@/lib/server/users";
 import {
   Card,
@@ -29,14 +43,17 @@ export const Route = createFileRoute("/companies/$id")({
     const companyId = parseInt(params.id);
     const company = await getCompanyById({ data: { companyId } });
     const stakeholders = await getCompanyStakeholders({ data: { companyId } });
+    const priceHistory = await getSharePriceHistory();
     const userData = await getCurrentUserInfo();
-    return { company, stakeholders, userData };
+    return { company, stakeholders, priceHistory, userData };
   },
   component: CompanyDetailPage,
 });
 
 function CompanyDetailPage() {
-  const { company, stakeholders, userData } = Route.useLoaderData();
+  const { company, stakeholders, priceHistory, userData } =
+    Route.useLoaderData();
+  const [chartRange, setChartRange] = useState<"24h" | "48h">("48h");
 
   if (!company) {
     return (
@@ -243,6 +260,13 @@ function CompanyDetailPage() {
           </Card>
         </div>
 
+        <StockPriceChart
+          priceHistory={priceHistory}
+          stockId={company.id}
+          chartRange={chartRange}
+          setChartRange={setChartRange}
+        />
+
         {/* Stakeholders */}
         <Card>
           <CardHeader>
@@ -320,5 +344,175 @@ function CompanyDetailPage() {
         </Card>
       </div>
     </div>
+  );
+}
+
+function StockPriceChart({
+  priceHistory,
+  stockId,
+  chartRange,
+  setChartRange,
+}: {
+  priceHistory: Array<{
+    id: number;
+    stockId: number | null;
+    price: number;
+    recordedAt: Date | null;
+    companyName: string;
+    companySymbol: string;
+    companyColor: string | null;
+  }>;
+  stockId: number;
+  chartRange: "24h" | "48h";
+  setChartRange: (range: "24h" | "48h") => void;
+}) {
+  const chartData = useMemo(() => {
+    const now = Date.now();
+    const cutoff =
+      chartRange === "24h"
+        ? now - 24 * 60 * 60 * 1000
+        : now - 48 * 60 * 60 * 1000;
+
+    return priceHistory
+      .filter(
+        (h) =>
+          h.stockId === stockId &&
+          h.recordedAt &&
+          new Date(h.recordedAt).getTime() >= cutoff,
+      )
+      .sort(
+        (a, b) =>
+          new Date(a.recordedAt!).getTime() - new Date(b.recordedAt!).getTime(),
+      )
+      .map((h) => ({
+        time: new Date(h.recordedAt!).getTime(),
+        price: h.price,
+      }));
+  }, [priceHistory, stockId, chartRange]);
+
+  const priceChange = useMemo(() => {
+    if (chartData.length < 2) return 0;
+    const oldPrice = chartData[0].price;
+    const newPrice = chartData[chartData.length - 1].price;
+    return ((newPrice - oldPrice) / oldPrice) * 100;
+  }, [chartData]);
+
+  const isPositive = priceChange >= 0;
+  const strokeColor =
+    priceChange === 0 ? "#9ca3af" : isPositive ? "#16a34a" : "#dc2626";
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-primary/10">
+              <TrendingUp className="h-5 w-5 text-primary" />
+            </div>
+            <div>
+              <CardTitle>Stock Price</CardTitle>
+              {chartData.length > 1 && (
+                <div
+                  className={`text-sm flex items-center gap-1 mt-0.5 ${
+                    priceChange === 0
+                      ? "text-muted-foreground"
+                      : isPositive
+                        ? "text-green-600"
+                        : "text-red-600"
+                  }`}
+                >
+                  {isPositive ? (
+                    <TrendingUp className="h-3.5 w-3.5" />
+                  ) : (
+                    <TrendingDown className="h-3.5 w-3.5" />
+                  )}
+                  {isPositive ? "+" : ""}
+                  {priceChange.toFixed(2)}% ({chartRange})
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-1 bg-muted rounded-lg p-1">
+            {(["24h", "48h"] as const).map((range) => (
+              <Button
+                key={range}
+                variant={chartRange === range ? "default" : "ghost"}
+                size="sm"
+                className="h-7 px-3 text-xs"
+                onClick={() => setChartRange(range)}
+              >
+                {range}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {chartData.length < 2 ? (
+          <div className="flex items-center justify-center h-48 text-muted-foreground text-sm">
+            Not enough price data yet
+          </div>
+        ) : (
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={chartData}>
+                <defs>
+                  <linearGradient
+                    id={`gradient-${stockId}`}
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop
+                      offset="5%"
+                      stopColor={strokeColor}
+                      stopOpacity={0.2}
+                    />
+                    <stop
+                      offset="95%"
+                      stopColor={strokeColor}
+                      stopOpacity={0}
+                    />
+                  </linearGradient>
+                </defs>
+                <XAxis
+                  dataKey="time"
+                  type="number"
+                  domain={["dataMin", "dataMax"]}
+                  hide
+                />
+                <YAxis domain={["dataMin - 5", "dataMax + 5"]} hide />
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.length) return null;
+                    const data = payload[0].payload;
+                    return (
+                      <div className="bg-popover border rounded-lg px-3 py-2 shadow-md text-sm">
+                        <div className="font-semibold">
+                          ${data.price.toLocaleString()}
+                        </div>
+                        <div className="text-muted-foreground text-xs">
+                          {new Date(data.time).toLocaleString()}
+                        </div>
+                      </div>
+                    );
+                  }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="price"
+                  stroke={strokeColor}
+                  strokeWidth={2}
+                  fill={`url(#gradient-${stockId})`}
+                  dot={false}
+                  activeDot={{ r: 4, strokeWidth: 2 }}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 }

--- a/src/routes/companies/create.tsx
+++ b/src/routes/companies/create.tsx
@@ -35,6 +35,7 @@ function CreateCompanyPage() {
   const [companySymbol, setCompanySymbol] = useState("");
   const [companyDescription, setCompanyDescription] = useState("");
   const [companyCapital, setCompanyCapital] = useState(100);
+  const [capitalInput, setCapitalInput] = useState("100");
   const [selectedLogo, setSelectedLogo] = useState<string | null>(null);
   const [companyColor, setCompanyColor] = useState("#3b82f6");
   const [isCreating, setIsCreating] = useState(false);
@@ -251,18 +252,25 @@ function CreateCompanyPage() {
                     min={100}
                     max={maxCapital}
                     step={100}
-                    value={companyCapital}
-                    onChange={(e) =>
-                      setCompanyCapital(
-                        Math.max(
-                          100,
-                          Math.min(
-                            Math.floor(Number(e.target.value) / 100) * 100,
-                            maxCapital,
-                          ),
+                    value={capitalInput}
+                    onChange={(e) => {
+                      setCapitalInput(e.target.value);
+                      const num = Number(e.target.value);
+                      if (!isNaN(num)) {
+                        setCompanyCapital(Math.floor(num / 100) * 100);
+                      }
+                    }}
+                    onBlur={() => {
+                      const clamped = Math.max(
+                        100,
+                        Math.min(
+                          Math.floor(Number(capitalInput) / 100) * 100,
+                          maxCapital,
                         ),
-                      )
-                    }
+                      );
+                      setCompanyCapital(clamped);
+                      setCapitalInput(String(clamped));
+                    }}
                   />
                   <p className="text-sm text-muted-foreground">
                     $100 per share &middot; {totalShares} shares will be created

--- a/src/routes/companies/index.tsx
+++ b/src/routes/companies/index.tsx
@@ -1,12 +1,26 @@
 import { Link, createFileRoute } from "@tanstack/react-router";
-import { Building2, TrendingDown, TrendingUp } from "lucide-react";
+import { Building2, Search, TrendingDown, TrendingUp } from "lucide-react";
+import { useMemo, useState } from "react";
 import { Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import * as LucideIcons from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { getCompanies, getSharePriceHistory } from "@/lib/server/stocks";
+import { getCurrentUserInfo } from "@/lib/server/users";
+import {
+  getCompanies,
+  getSharePriceHistory,
+  getUserShares,
+} from "@/lib/server/stocks";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { calculateMarketCap } from "@/lib/utils/stock-economy";
 
 export const Route = createFileRoute("/companies/")({
@@ -14,16 +28,141 @@ export const Route = createFileRoute("/companies/")({
   loader: async () => {
     const companies = await getCompanies();
     const priceHistory = await getSharePriceHistory();
-    return { companies, priceHistory };
+    const userData = await getCurrentUserInfo();
+
+    let userHoldings: Array<{
+      id: number;
+      quantity: number | null;
+      companyId: number;
+    }> = [];
+
+    if (
+      userData &&
+      typeof userData === "object" &&
+      "id" in userData &&
+      userData.id
+    ) {
+      try {
+        userHoldings = await getUserShares();
+      } catch {
+        userHoldings = [];
+      }
+    }
+
+    return { companies, priceHistory, userHoldings };
   },
 });
 
 function CompaniesPage() {
-  const { companies, priceHistory } = Route.useLoaderData();
+  const { companies, priceHistory, userHoldings } = Route.useLoaderData();
+  const [search, setSearch] = useState("");
+  const [sortBy, setSortBy] = useState("name-asc");
+  const [filterHoldings, setFilterHoldings] = useState(false);
+
+  const heldCompanyIds = useMemo(
+    () =>
+      new Set(
+        userHoldings
+          .filter((h) => (h.quantity || 0) > 0)
+          .map((h) => h.companyId),
+      ),
+    [userHoldings],
+  );
+
+  // Pre-compute derived data for each company
+  const enrichedCompanies = useMemo(() => {
+    return companies.map((company) => {
+      const marketCap = calculateMarketCap({
+        sharePrice: company.stockPrice,
+        issuedShares: company.issuedShares,
+      });
+
+      const companyHistory = priceHistory.filter(
+        (h) => h.stockId === company.id,
+      );
+      const now = Date.now();
+      const twentyFourHoursAgo = now - 24 * 60 * 60 * 1000;
+      const last24Hours = companyHistory
+        .filter((h) => new Date(h.recordedAt!).getTime() >= twentyFourHoursAgo)
+        .sort(
+          (a, b) =>
+            new Date(a.recordedAt!).getTime() -
+            new Date(b.recordedAt!).getTime(),
+        );
+
+      const chartData = last24Hours.map((h) => ({
+        time: new Date(h.recordedAt!).getTime(),
+        price: h.price,
+      }));
+
+      let priceChange = 0;
+      if (chartData.length > 1) {
+        const oldPrice = chartData[0].price;
+        const newPrice = chartData[chartData.length - 1].price;
+        priceChange = ((newPrice - oldPrice) / oldPrice) * 100;
+      }
+
+      let LogoIcon: LucideIcon | null = null;
+      if (company.logo) {
+        const iconsMap = LucideIcons as unknown as Record<string, LucideIcon>;
+        LogoIcon = iconsMap[company.logo] || null;
+      }
+
+      return { company, marketCap, chartData, priceChange, LogoIcon };
+    });
+  }, [companies, priceHistory]);
+
+  // Filter & sort
+  const filteredCompanies = useMemo(() => {
+    let result = enrichedCompanies;
+
+    // Search
+    if (search.trim()) {
+      const q = search.trim().toLowerCase();
+      result = result.filter(
+        ({ company }) =>
+          company.name.toLowerCase().includes(q) ||
+          company.symbol.toLowerCase().includes(q),
+      );
+    }
+
+    // My Holdings filter
+    if (filterHoldings) {
+      result = result.filter(({ company }) => heldCompanyIds.has(company.id));
+    }
+
+    // Sort
+    result = [...result].sort((a, b) => {
+      switch (sortBy) {
+        case "price-asc":
+          return (a.company.stockPrice || 0) - (b.company.stockPrice || 0);
+        case "price-desc":
+          return (b.company.stockPrice || 0) - (a.company.stockPrice || 0);
+        case "change-asc":
+          return a.priceChange - b.priceChange;
+        case "change-desc":
+          return b.priceChange - a.priceChange;
+        case "mcap-asc":
+          return a.marketCap - b.marketCap;
+        case "mcap-desc":
+          return b.marketCap - a.marketCap;
+        case "newest":
+          return (
+            new Date(b.company.createdAt || 0).getTime() -
+            new Date(a.company.createdAt || 0).getTime()
+          );
+        case "name-asc":
+        default:
+          return a.company.name.localeCompare(b.company.name);
+      }
+    });
+
+    return result;
+  }, [enrichedCompanies, search, filterHoldings, sortBy, heldCompanyIds]);
 
   return (
-    <div className="container max-w-6xl mx-auto px-4 py-8">
-      <div className="mb-8">
+    <div className="container max-w-6xl mx-auto px-4 py-8 space-y-6">
+      <div>
         <div className="mb-4">
           <h1 className="text-4xl font-bold">Companies</h1>
           <p className="text-muted-foreground mt-2">
@@ -46,6 +185,46 @@ function CompaniesPage() {
         </div>
       </div>
 
+      {/* Search & Filters */}
+      <div className="flex flex-col sm:flex-row gap-3">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by name or symbol…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <div className="flex gap-2">
+          {userHoldings.length > 0 && (
+            <Button
+              variant={filterHoldings ? "default" : "outline"}
+              onClick={() => setFilterHoldings(!filterHoldings)}
+              size="sm"
+              className="whitespace-nowrap h-9"
+            >
+              My Holdings
+            </Button>
+          )}
+          <Select value={sortBy} onValueChange={setSortBy}>
+            <SelectTrigger className="w-[180px] h-9">
+              <SelectValue placeholder="Sort by" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="name-asc">Name (A–Z)</SelectItem>
+              <SelectItem value="price-desc">Price (High → Low)</SelectItem>
+              <SelectItem value="price-asc">Price (Low → High)</SelectItem>
+              <SelectItem value="change-desc">Change (High → Low)</SelectItem>
+              <SelectItem value="change-asc">Change (Low → High)</SelectItem>
+              <SelectItem value="mcap-desc">Market Cap (High → Low)</SelectItem>
+              <SelectItem value="mcap-asc">Market Cap (Low → High)</SelectItem>
+              <SelectItem value="newest">Newest First</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
       {companies.length === 0 ? (
         <Card>
           <CardContent className="py-12 text-center">
@@ -53,189 +232,159 @@ function CompaniesPage() {
             <p className="text-muted-foreground">No companies registered yet</p>
           </CardContent>
         </Card>
+      ) : filteredCompanies.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <Search className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+            <p className="text-muted-foreground">
+              No companies match your search
+            </p>
+          </CardContent>
+        </Card>
       ) : (
         <div className="space-y-4">
-          {companies.map((company) => {
-            const marketCap = calculateMarketCap({
-              sharePrice: company.stockPrice,
-              issuedShares: company.issuedShares,
-            });
-
-            const companyHistory = priceHistory.filter(
-              (h) => h.stockId === company.id,
-            );
-            const now = Date.now();
-            const twentyFourHoursAgo = now - 24 * 60 * 60 * 1000;
-            const last24Hours = companyHistory
-              .filter(
-                (h) => new Date(h.recordedAt!).getTime() >= twentyFourHoursAgo,
-              )
-              .sort(
-                (a, b) =>
-                  new Date(a.recordedAt!).getTime() -
-                  new Date(b.recordedAt!).getTime(),
-              );
-
-            const chartData = last24Hours.map((h) => ({
-              time: new Date(h.recordedAt!).getTime(),
-              price: h.price,
-            }));
-
-            let priceChange = 0;
-            if (chartData.length > 1) {
-              const oldPrice = chartData[0].price;
-              const newPrice = chartData[chartData.length - 1].price;
-              priceChange = ((newPrice - oldPrice) / oldPrice) * 100;
-            }
-
-            let LogoIcon: LucideIcon | null = null;
-            if (company.logo) {
-              const iconsMap = LucideIcons as unknown as Record<
-                string,
-                LucideIcon
-              >;
-              LogoIcon = iconsMap[company.logo] || null;
-            }
-
-            return (
-              <Link
-                key={company.id}
-                to="/companies/$id"
-                params={{ id: String(company.id) }}
-                className="block"
-              >
-                <Card className="hover:bg-accent/50 transition-colors">
-                  <CardContent className="p-6">
-                    <div className="flex flex-col lg:flex-row gap-6">
-                      <div className="flex-1">
-                        <div className="flex items-start gap-4 mb-4">
-                          <div
-                            className="h-16 w-16 rounded-lg flex items-center justify-center font-bold text-2xl"
-                            style={{
-                              backgroundColor: company.color
-                                ? `${company.color}20`
-                                : "hsl(var(--primary) / 0.1)",
-                              color: company.color || "hsl(var(--primary))",
-                            }}
-                          >
-                            {LogoIcon ? (
-                              <LogoIcon className="w-8 h-8" />
-                            ) : (
-                              company.symbol.charAt(0)
-                            )}
-                          </div>
-                          <div className="flex-1">
-                            <div className="flex items-center gap-2">
-                              <h3 className="text-2xl font-bold">
-                                {company.name}
-                              </h3>
-                              <Badge variant="secondary">
-                                {company.symbol}
-                              </Badge>
+          {filteredCompanies.map(
+            ({ company, marketCap, chartData, priceChange, LogoIcon }) => {
+              return (
+                <Link
+                  key={company.id}
+                  to="/companies/$id"
+                  params={{ id: String(company.id) }}
+                  className="block"
+                >
+                  <Card className="hover:bg-accent/50 transition-colors">
+                    <CardContent className="p-6">
+                      <div className="flex flex-col lg:flex-row gap-6">
+                        <div className="flex-1">
+                          <div className="flex items-start gap-4 mb-4">
+                            <div
+                              className="h-16 w-16 rounded-lg flex items-center justify-center font-bold text-2xl"
+                              style={{
+                                backgroundColor: company.color
+                                  ? `${company.color}20`
+                                  : "hsl(var(--primary) / 0.1)",
+                                color: company.color || "hsl(var(--primary))",
+                              }}
+                            >
+                              {LogoIcon ? (
+                                <LogoIcon className="w-8 h-8" />
+                              ) : (
+                                company.symbol.charAt(0)
+                              )}
                             </div>
-                            {company.description && (
-                              <p className="text-sm text-muted-foreground mt-1 break-all overflow-hidden">
-                                {company.description.length > 200
-                                  ? company.description.slice(0, 200) + "…"
-                                  : company.description}
-                              </p>
-                            )}
-                          </div>
-                        </div>
-
-                        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-                          <div>
-                            <div className="text-sm text-muted-foreground">
-                              Stock Price
-                            </div>
-                            <div className="text-xl font-bold">
-                              ${company.stockPrice?.toLocaleString() || "N/A"}
-                            </div>
-                            {chartData.length > 1 && (
-                              <div
-                                className={`text-sm flex items-center gap-1 ${
-                                  priceChange === 0
-                                    ? "text-muted-foreground"
-                                    : priceChange > 0
-                                      ? "text-green-600"
-                                      : "text-red-600"
-                                }`}
-                              >
-                                {priceChange === 0 ? (
-                                  <TrendingUp className="h-4 w-4" />
-                                ) : priceChange > 0 ? (
-                                  <TrendingUp className="h-4 w-4" />
-                                ) : (
-                                  <TrendingDown className="h-4 w-4" />
-                                )}
-                                {priceChange > 0 ? "+" : ""}
-                                {priceChange.toFixed(2)}% (24h)
+                            <div className="flex-1">
+                              <div className="flex items-center gap-2">
+                                <h3 className="text-2xl font-bold">
+                                  {company.name}
+                                </h3>
+                                <Badge variant="secondary">
+                                  {company.symbol}
+                                </Badge>
                               </div>
-                            )}
-                          </div>
-                          <div>
-                            <div className="text-sm text-muted-foreground">
-                              Market Cap
-                            </div>
-                            <div className="text-xl font-bold">
-                              ${marketCap.toLocaleString()}
-                            </div>
-                          </div>
-                          <div>
-                            <div className="text-sm text-muted-foreground">
-                              Shares
-                            </div>
-                            <div className="text-xl font-bold">
-                              {company.issuedShares?.toLocaleString() || 0}
+                              {company.description && (
+                                <p className="text-sm text-muted-foreground mt-1 break-all overflow-hidden">
+                                  {company.description.length > 200
+                                    ? company.description.slice(0, 200) + "…"
+                                    : company.description}
+                                </p>
+                              )}
                             </div>
                           </div>
-                          <div>
-                            <div className="text-sm text-muted-foreground">
-                              CEO
-                            </div>
-                            <div className="text-xl font-bold">
-                              {company.creatorUsername || "Unknown"}
-                            </div>
-                          </div>
-                        </div>
-                      </div>
 
-                      {chartData.length > 1 && (
-                        <div className="lg:w-64 h-24">
-                          <ResponsiveContainer width="100%" height="100%">
-                            <LineChart data={chartData}>
-                              <XAxis
-                                dataKey="time"
-                                hide
-                                domain={["dataMin", "dataMax"]}
-                              />
-                              <YAxis
-                                hide
-                                domain={["dataMin - 5", "dataMax + 5"]}
-                              />
-                              <Line
-                                type="monotone"
-                                dataKey="price"
-                                stroke={
-                                  priceChange === 0
-                                    ? "#9ca3af"
-                                    : priceChange > 0
-                                      ? "#16a34a"
-                                      : "#dc2626"
-                                }
-                                strokeWidth={2}
-                                dot={false}
-                              />
-                            </LineChart>
-                          </ResponsiveContainer>
+                          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+                            <div>
+                              <div className="text-sm text-muted-foreground">
+                                Stock Price
+                              </div>
+                              <div className="text-xl font-bold">
+                                ${company.stockPrice?.toLocaleString() || "N/A"}
+                              </div>
+                              {chartData.length > 1 && (
+                                <div
+                                  className={`text-sm flex items-center gap-1 ${
+                                    priceChange === 0
+                                      ? "text-muted-foreground"
+                                      : priceChange > 0
+                                        ? "text-green-600"
+                                        : "text-red-600"
+                                  }`}
+                                >
+                                  {priceChange === 0 ? (
+                                    <TrendingUp className="h-4 w-4" />
+                                  ) : priceChange > 0 ? (
+                                    <TrendingUp className="h-4 w-4" />
+                                  ) : (
+                                    <TrendingDown className="h-4 w-4" />
+                                  )}
+                                  {priceChange > 0 ? "+" : ""}
+                                  {priceChange.toFixed(2)}% (24h)
+                                </div>
+                              )}
+                            </div>
+                            <div>
+                              <div className="text-sm text-muted-foreground">
+                                Market Cap
+                              </div>
+                              <div className="text-xl font-bold">
+                                ${marketCap.toLocaleString()}
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-sm text-muted-foreground">
+                                Shares
+                              </div>
+                              <div className="text-xl font-bold">
+                                {company.issuedShares?.toLocaleString() || 0}
+                              </div>
+                            </div>
+                            <div>
+                              <div className="text-sm text-muted-foreground">
+                                CEO
+                              </div>
+                              <div className="text-xl font-bold">
+                                {company.creatorUsername || "Unknown"}
+                              </div>
+                            </div>
+                          </div>
                         </div>
-                      )}
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            );
-          })}
+
+                        {chartData.length > 1 && (
+                          <div className="lg:w-64 h-24">
+                            <ResponsiveContainer width="100%" height="100%">
+                              <LineChart data={chartData}>
+                                <XAxis
+                                  dataKey="time"
+                                  hide
+                                  domain={["dataMin", "dataMax"]}
+                                />
+                                <YAxis
+                                  hide
+                                  domain={["dataMin - 5", "dataMax + 5"]}
+                                />
+                                <Line
+                                  type="monotone"
+                                  dataKey="price"
+                                  stroke={
+                                    priceChange === 0
+                                      ? "#9ca3af"
+                                      : priceChange > 0
+                                        ? "#16a34a"
+                                        : "#dc2626"
+                                  }
+                                  strokeWidth={2}
+                                  dot={false}
+                                />
+                              </LineChart>
+                            </ResponsiveContainer>
+                          </div>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                </Link>
+              );
+            },
+          )}
         </div>
       )}
     </div>

--- a/src/routes/companies/market.tsx
+++ b/src/routes/companies/market.tsx
@@ -18,6 +18,8 @@ import {
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
 import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 import * as LucideIcons from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -50,13 +52,6 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 
 export const Route = createFileRoute("/companies/market")({
   loader: async () => {
@@ -206,32 +201,33 @@ function HoldingItem({ holding }: { holding: any }) {
         </div>
       </div>
 
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex gap-4">
-          <div className="flex flex-col">
-            <span className="text-lg font-bold">
-              {(holding.quantity || 0).toLocaleString()}
-            </span>
-            <span className="text-xs text-muted-foreground">Shares</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-lg font-bold">
-              ${(holding.stockPrice || 0).toLocaleString()}
-            </span>
-            <span className="text-xs text-muted-foreground">Price</span>
-          </div>
-          <div className="flex flex-col">
-            <span className="text-lg font-bold text-muted-foreground">
-              $
-              {(
-                (holding.quantity || 0) * (holding.stockPrice || 0)
-              ).toLocaleString()}
-            </span>
-            <span className="text-xs text-muted-foreground">Value</span>
-          </div>
+      <div className="grid grid-cols-3 gap-2 text-center">
+        <div className="flex flex-col">
+          <span className="text-lg font-bold">
+            {(holding.quantity || 0).toLocaleString()}
+          </span>
+          <span className="text-xs text-muted-foreground">Shares</span>
         </div>
+        <div className="flex flex-col">
+          <span className="text-lg font-bold">
+            ${(holding.stockPrice || 0).toLocaleString()}
+          </span>
+          <span className="text-xs text-muted-foreground">Price</span>
+        </div>
+        <div className="flex flex-col">
+          <span className="text-lg font-bold text-muted-foreground">
+            $
+            {(
+              (holding.quantity || 0) * (holding.stockPrice || 0)
+            ).toLocaleString()}
+          </span>
+          <span className="text-xs text-muted-foreground">Value</span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
         <form
-          className="flex items-center gap-2"
+          className="flex items-center gap-2 flex-1"
           onSubmit={async (e) => {
             e.preventDefault();
             if (!holding.companyId || !sellQty || sellQty < 1) return;
@@ -300,6 +296,7 @@ function HoldingItem({ holding }: { holding: any }) {
             type="submit"
             variant="destructive"
             size="sm"
+            className="flex-1 sm:flex-initial"
             disabled={isSelling || (holding.quantity || 0) < 1}
           >
             {isSelling ? "..." : "Sell"}
@@ -335,44 +332,44 @@ function OrderItem({
 
   return (
     <div className="p-4 rounded-lg border bg-card space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <div
-            className="flex items-center justify-center w-10 h-10 rounded-lg font-bold text-sm shrink-0"
-            style={{
-              backgroundColor: order.companyColor
-                ? `${order.companyColor}20`
-                : "hsl(var(--primary) / 0.1)",
-              color: order.companyColor || "hsl(var(--primary))",
-            }}
-          >
-            {LogoIcon ? (
-              <LogoIcon className="w-5 h-5" />
-            ) : (
-              order.companySymbol?.slice(0, 2)
-            )}
+      <div className="flex items-start gap-3">
+        <div
+          className="flex items-center justify-center w-10 h-10 rounded-lg font-bold text-sm shrink-0"
+          style={{
+            backgroundColor: order.companyColor
+              ? `${order.companyColor}20`
+              : "hsl(var(--primary) / 0.1)",
+            color: order.companyColor || "hsl(var(--primary))",
+          }}
+        >
+          {LogoIcon ? (
+            <LogoIcon className="w-5 h-5" />
+          ) : (
+            order.companySymbol?.slice(0, 2)
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <Badge
+              variant={isBuy ? "default" : "destructive"}
+              className="text-[10px] uppercase tracking-wider"
+            >
+              {order.side}
+            </Badge>
+            <h3 className="font-semibold truncate">{order.companyName}</h3>
+            <span className="text-xs px-2 py-0.5 bg-muted rounded font-mono shrink-0">
+              {order.companySymbol}
+            </span>
           </div>
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <Badge
-                variant={isBuy ? "default" : "destructive"}
-                className="text-[10px] uppercase tracking-wider"
-              >
-                {order.side}
-              </Badge>
-              <h3 className="font-semibold truncate">{order.companyName}</h3>
-              <span className="text-xs px-2 py-0.5 bg-muted rounded font-mono shrink-0">
-                {order.companySymbol}
-              </span>
-            </div>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1">
             <p className="text-xs text-muted-foreground">
               {order.createdAt
                 ? new Date(order.createdAt).toLocaleString()
                 : "N/A"}
             </p>
+            <OrderStatusBadge status={order.status} />
           </div>
         </div>
-        <OrderStatusBadge status={order.status} />
       </div>
 
       <div className="grid grid-cols-3 gap-3 text-center">
@@ -488,6 +485,7 @@ function MarketPage() {
     }>;
   } | null>(null);
   const [orderBookLoading, setOrderBookLoading] = useState(false);
+  const [orderBookSearch, setOrderBookSearch] = useState("");
 
   useEffect(() => {
     if (!orderBookCompanyId) {
@@ -854,11 +852,11 @@ function MarketPage() {
 
         {/* Orders & Holdings in Tabs */}
         <Tabs defaultValue="orders" className="w-full">
-          <TabsList className="w-full grid grid-cols-4">
-            <TabsTrigger value="orders" className="gap-1.5">
-              <ListOrdered className="w-4 h-4" />
+          <TabsList className="w-full flex overflow-x-auto no-scrollbar">
+            <TabsTrigger value="orders" className="gap-1.5 flex-1 min-w-0">
+              <ListOrdered className="w-4 h-4 shrink-0" />
               <span className="hidden sm:inline">My Orders</span>
-              <span className="sm:hidden">Orders</span>
+              <span className="sm:hidden text-xs">Orders</span>
               {activeOrders.length > 0 && (
                 <Badge
                   variant="default"
@@ -868,10 +866,10 @@ function MarketPage() {
                 </Badge>
               )}
             </TabsTrigger>
-            <TabsTrigger value="holdings" className="gap-1.5">
-              <Briefcase className="w-4 h-4" />
+            <TabsTrigger value="holdings" className="gap-1.5 flex-1 min-w-0">
+              <Briefcase className="w-4 h-4 shrink-0" />
               <span className="hidden sm:inline">Holdings</span>
-              <span className="sm:hidden">Hold</span>
+              <span className="sm:hidden text-xs">Hold</span>
               {userHoldings.length > 0 && (
                 <Badge
                   variant="secondary"
@@ -881,14 +879,14 @@ function MarketPage() {
                 </Badge>
               )}
             </TabsTrigger>
-            <TabsTrigger value="orderbook" className="gap-1.5">
-              <BarChart3 className="w-4 h-4" />
+            <TabsTrigger value="orderbook" className="gap-1.5 flex-1 min-w-0">
+              <BarChart3 className="w-4 h-4 shrink-0" />
               <span className="hidden sm:inline">Order Book</span>
-              <span className="sm:hidden">Book</span>
+              <span className="sm:hidden text-xs">Book</span>
             </TabsTrigger>
-            <TabsTrigger value="market" className="gap-1.5">
-              <ShoppingCart className="w-4 h-4" />
-              Market
+            <TabsTrigger value="market" className="gap-1.5 flex-1 min-w-0">
+              <ShoppingCart className="w-4 h-4 shrink-0" />
+              <span className="text-xs sm:text-sm">Market</span>
             </TabsTrigger>
           </TabsList>
 
@@ -1017,27 +1015,83 @@ function MarketPage() {
                   See who&apos;s in the queue and your position. Orders are
                   matched hourly in FIFO order.
                 </CardDescription>
-                <div className="mt-3">
-                  <Select
-                    value={orderBookCompanyId?.toString() ?? ""}
-                    onValueChange={(val) =>
-                      setOrderBookCompanyId(val ? Number(val) : null)
-                    }
-                  >
-                    <SelectTrigger className="w-full sm:w-[280px]">
-                      <SelectValue placeholder="Select a company" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {companiesList.map((company) => (
-                        <SelectItem
-                          key={company.id}
-                          value={company.id.toString()}
-                        >
-                          {company.symbol} — {company.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                <div className="mt-3 space-y-2">
+                  <div className="relative">
+                    <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                    <Input
+                      placeholder="Search companies…"
+                      value={orderBookSearch}
+                      onChange={(e) => setOrderBookSearch(e.target.value)}
+                      className="pl-9"
+                    />
+                  </div>
+                  <div className="max-h-48 overflow-y-auto rounded-lg border">
+                    {companiesList
+                      .filter((c) => {
+                        if (!orderBookSearch.trim()) return true;
+                        const q = orderBookSearch.trim().toLowerCase();
+                        return (
+                          c.name.toLowerCase().includes(q) ||
+                          c.symbol.toLowerCase().includes(q)
+                        );
+                      })
+                      .map((company) => {
+                        const isSelected = orderBookCompanyId === company.id;
+                        let LogoIcon: LucideIcon | null = null;
+                        if (company.logo) {
+                          const iconsMap = LucideIcons as unknown as Record<
+                            string,
+                            LucideIcon
+                          >;
+                          LogoIcon = iconsMap[company.logo] || null;
+                        }
+                        return (
+                          <button
+                            key={company.id}
+                            type="button"
+                            className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors hover:bg-accent ${
+                              isSelected ? "bg-primary/10 font-semibold" : ""
+                            }`}
+                            onClick={() => {
+                              setOrderBookCompanyId(company.id);
+                              setOrderBookSearch("");
+                            }}
+                          >
+                            <div
+                              className="w-7 h-7 rounded flex items-center justify-center text-xs font-bold shrink-0"
+                              style={{
+                                backgroundColor: company.color
+                                  ? `${company.color}20`
+                                  : "hsl(var(--primary) / 0.1)",
+                                color: company.color || "hsl(var(--primary))",
+                              }}
+                            >
+                              {LogoIcon ? (
+                                <LogoIcon className="w-3.5 h-3.5" />
+                              ) : (
+                                company.symbol.charAt(0)
+                              )}
+                            </div>
+                            <span className="font-mono text-xs shrink-0">
+                              {company.symbol}
+                            </span>
+                            <span className="truncate">{company.name}</span>
+                          </button>
+                        );
+                      })}
+                    {companiesList.filter((c) => {
+                      if (!orderBookSearch.trim()) return true;
+                      const q = orderBookSearch.trim().toLowerCase();
+                      return (
+                        c.name.toLowerCase().includes(q) ||
+                        c.symbol.toLowerCase().includes(q)
+                      );
+                    }).length === 0 && (
+                      <p className="text-sm text-muted-foreground text-center py-4">
+                        No companies found
+                      </p>
+                    )}
+                  </div>
                 </div>
               </CardHeader>
               <CardContent>
@@ -1380,7 +1434,7 @@ function MarketPage() {
                             </div>
                           </Link>
 
-                          <div className="grid grid-cols-4 gap-2">
+                          <div className="grid grid-cols-5 gap-2">
                             <div className="flex flex-col items-center">
                               <span className="text-lg font-bold">
                                 ${company.stockPrice?.toLocaleString() ?? "N/A"}
@@ -1410,6 +1464,17 @@ function MarketPage() {
                                   Price
                                 </span>
                               )}
+                            </div>
+
+                            <div className="flex flex-col items-center">
+                              <span className="text-lg font-semibold text-blue-600 dark:text-blue-400">
+                                {Number(
+                                  company.buyOrderShares ?? 0,
+                                ).toLocaleString()}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                Buyers
+                              </span>
                             </div>
 
                             <div className="flex flex-col items-center">

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,42 +4,39 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
-  /* === Light Mode — Natural & Institutional === */
-  --background: oklch(0.97 0.01 115); /* pale parchment with green tint */
-  --foreground: oklch(0.26 0.04 140); /* deep moss text */
+  --background: oklch(0.97 0.01 115);
+  --foreground: oklch(0.26 0.04 140);
 
   --card: oklch(0.985 0.005 115);
   --card-foreground: var(--foreground);
   --popover: oklch(0.985 0.005 115);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.55 0.09 145); /* balanced natural green */
+  --primary: oklch(0.55 0.09 145);
   --primary-foreground: oklch(0.99 0.005 115);
 
-  --secondary: oklch(0.84 0.03 100); /* paper gray-green */
+  --secondary: oklch(0.84 0.03 100);
   --secondary-foreground: oklch(0.26 0.04 140);
 
   --muted: oklch(0.9 0.015 115);
   --muted-foreground: oklch(0.45 0.04 135);
 
-  --accent: oklch(0.78 0.04 145); /* soft minty highlight */
+  --accent: oklch(0.78 0.04 145);
   --accent-foreground: oklch(0.24 0.05 140);
 
-  --destructive: oklch(0.56 0.14 30); /* muted red */
+  --destructive: oklch(0.56 0.14 30);
   --destructive-foreground: oklch(0.98 0.005 115);
 
   --border: oklch(0.83 0.015 115);
   --input: oklch(0.83 0.015 115);
   --ring: oklch(0.55 0.09 145);
 
-  /* Charts — calm green range */
   --chart-1: oklch(0.55 0.09 145);
   --chart-2: oklch(0.59 0.08 140);
   --chart-3: oklch(0.51 0.07 135);
   --chart-4: oklch(0.47 0.07 125);
   --chart-5: oklch(0.42 0.06 115);
 
-  /* Sidebar */
   --sidebar: oklch(0.935 0.01 115);
   --sidebar-foreground: oklch(0.28 0.04 135);
   --sidebar-primary: var(--primary);
@@ -49,12 +46,10 @@
   --sidebar-border: var(--border);
   --sidebar-ring: var(--ring);
 
-  /* Fonts */
   --font-sans: Plus Jakarta Sans, sans-serif;
   --font-serif: Lora, serif;
   --font-mono: Roboto Mono, monospace;
 
-  /* Radius & Shadows */
   --radius: 1.25rem;
   --shadow-color: #7d867a;
   --shadow-2xs: 0 1px 3px hsl(120 10% 40% / 0.08);
@@ -71,8 +66,7 @@
 }
 
 .dark {
-  /* === Dark Mode — Tempered Forest Bureaucracy === */
-  --background: oklch(0.19 0.01 130); /* dark slate-moss */
+  --background: oklch(0.19 0.01 130);
   --foreground: oklch(0.9 0.015 115);
 
   --card: oklch(0.23 0.012 130);
@@ -80,33 +74,31 @@
   --popover: oklch(0.23 0.012 130);
   --popover-foreground: var(--foreground);
 
-  --primary: oklch(0.58 0.07 150); /* softer moss green */
+  --primary: oklch(0.58 0.07 150);
   --primary-foreground: oklch(0.2 0.012 130);
 
-  --secondary: oklch(0.32 0.02 100); /* gray-olive */
+  --secondary: oklch(0.32 0.02 100);
   --secondary-foreground: oklch(0.85 0.015 115);
 
   --muted: oklch(0.23 0.012 130);
   --muted-foreground: oklch(0.7 0.03 135);
 
-  --accent: oklch(0.38 0.04 145); /* quiet, supportive green */
+  --accent: oklch(0.38 0.04 145);
   --accent-foreground: oklch(0.88 0.015 115);
 
-  --destructive: oklch(0.47 0.11 30); /* muted red */
+  --destructive: oklch(0.47 0.11 30);
   --destructive-foreground: oklch(0.9 0.015 115);
 
   --border: oklch(0.28 0.01 130);
   --input: var(--border);
   --ring: oklch(0.58 0.07 150);
 
-  /* Charts — darker and gentler */
   --chart-1: oklch(0.58 0.07 150);
   --chart-2: oklch(0.53 0.06 140);
   --chart-3: oklch(0.47 0.05 130);
   --chart-4: oklch(0.42 0.04 120);
   --chart-5: oklch(0.37 0.03 110);
 
-  /* Sidebar */
   --sidebar: oklch(0.25 0.01 130);
   --sidebar-foreground: oklch(0.9 0.015 115);
   --sidebar-primary: var(--primary);
@@ -130,6 +122,422 @@
   --shadow-lg: 0 4px 10px hsl(120 10% 3% / 0.2);
   --shadow-xl: 0 6px 14px hsl(120 10% 3% / 0.22);
   --shadow-2xl: 0 8px 18px hsl(120 10% 3% / 0.25);
+}
+
+.t3 {
+  --background: oklch(0.16 0.025 350);
+  --foreground: oklch(0.9 0.01 350);
+
+  --card: oklch(0.19 0.025 350);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.19 0.025 350);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.55 0.15 355);
+  --primary-foreground: oklch(0.96 0.005 350);
+
+  --secondary: oklch(0.23 0.02 350);
+  --secondary-foreground: oklch(0.88 0.01 350);
+
+  --muted: oklch(0.21 0.02 350);
+  --muted-foreground: oklch(0.55 0.03 350);
+
+  --accent: oklch(0.26 0.03 350);
+  --accent-foreground: oklch(0.9 0.01 350);
+
+  --destructive: oklch(0.55 0.18 20);
+  --destructive-foreground: oklch(0.9 0.01 350);
+
+  --border: oklch(0.25 0.02 350);
+  --input: oklch(0.22 0.025 350);
+  --ring: oklch(0.55 0.15 355);
+
+  --chart-1: oklch(0.55 0.15 355);
+  --chart-2: oklch(0.62 0.12 340);
+  --chart-3: oklch(0.68 0.1 30);
+  --chart-4: oklch(0.72 0.1 60);
+  --chart-5: oklch(0.5 0.12 320);
+
+  --sidebar: oklch(0.13 0.02 350);
+  --sidebar-foreground: oklch(0.9 0.01 350);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.96 0.005 350);
+  --sidebar-accent: oklch(0.22 0.03 350);
+  --sidebar-accent-foreground: oklch(0.9 0.01 350);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #000;
+  --shadow-2xs: 0 1px 3px hsl(350 30% 3% / 0.12);
+  --shadow-xs: 0 1px 3px hsl(350 30% 3% / 0.18);
+  --shadow-sm: 0 2px 4px hsl(350 30% 3% / 0.22);
+  --shadow: 0 2px 6px hsl(350 30% 3% / 0.25);
+  --shadow-md: 0 3px 8px hsl(350 30% 3% / 0.28);
+  --shadow-lg: 0 4px 10px hsl(350 30% 3% / 0.32);
+  --shadow-xl: 0 6px 14px hsl(350 30% 3% / 0.36);
+  --shadow-2xl: 0 8px 18px hsl(350 30% 3% / 0.4);
+}
+
+.dracula {
+  --background: oklch(0.22 0.02 280);
+  --foreground: oklch(0.93 0.01 300);
+
+  --card: oklch(0.26 0.02 280);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.26 0.02 280);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.7 0.16 310);
+  --primary-foreground: oklch(0.22 0.02 280);
+
+  --secondary: oklch(0.32 0.02 280);
+  --secondary-foreground: oklch(0.93 0.01 300);
+
+  --muted: oklch(0.28 0.02 280);
+  --muted-foreground: oklch(0.7 0.02 280);
+
+  --accent: oklch(0.75 0.12 60);
+  --accent-foreground: oklch(0.22 0.02 280);
+
+  --destructive: oklch(0.62 0.2 20);
+  --destructive-foreground: oklch(0.93 0.01 300);
+
+  --border: oklch(0.34 0.02 280);
+  --input: oklch(0.34 0.02 280);
+  --ring: oklch(0.7 0.16 310);
+
+  --chart-1: oklch(0.7 0.16 310);
+  --chart-2: oklch(0.72 0.18 170);
+  --chart-3: oklch(0.78 0.14 140);
+  --chart-4: oklch(0.75 0.12 60);
+  --chart-5: oklch(0.7 0.18 340);
+
+  --sidebar: oklch(0.2 0.02 280);
+  --sidebar-foreground: oklch(0.93 0.01 300);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.22 0.02 280);
+  --sidebar-accent: oklch(0.35 0.03 280);
+  --sidebar-accent-foreground: oklch(0.93 0.01 300);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #000;
+  --shadow-2xs: 0 1px 3px hsl(265 30% 5% / 0.1);
+  --shadow-xs: 0 1px 3px hsl(265 30% 5% / 0.15);
+  --shadow-sm: 0 2px 4px hsl(265 30% 5% / 0.18);
+  --shadow: 0 2px 6px hsl(265 30% 5% / 0.2);
+  --shadow-md: 0 3px 8px hsl(265 30% 5% / 0.22);
+  --shadow-lg: 0 4px 10px hsl(265 30% 5% / 0.25);
+  --shadow-xl: 0 6px 14px hsl(265 30% 5% / 0.28);
+  --shadow-2xl: 0 8px 18px hsl(265 30% 5% / 0.32);
+}
+
+.rose-pine {
+  --background: oklch(0.21 0.02 290);
+  --foreground: oklch(0.88 0.02 310);
+
+  --card: oklch(0.24 0.02 290);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.24 0.02 290);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.68 0.14 350);
+  --primary-foreground: oklch(0.21 0.02 290);
+
+  --secondary: oklch(0.3 0.02 290);
+  --secondary-foreground: oklch(0.88 0.02 310);
+
+  --muted: oklch(0.27 0.02 290);
+  --muted-foreground: oklch(0.62 0.04 290);
+
+  --accent: oklch(0.65 0.11 320);
+  --accent-foreground: oklch(0.21 0.02 290);
+
+  --destructive: oklch(0.6 0.16 20);
+  --destructive-foreground: oklch(0.88 0.02 310);
+
+  --border: oklch(0.33 0.02 290);
+  --input: oklch(0.33 0.02 290);
+  --ring: oklch(0.68 0.14 350);
+
+  --chart-1: oklch(0.68 0.14 350);
+  --chart-2: oklch(0.65 0.11 320);
+  --chart-3: oklch(0.72 0.11 80);
+  --chart-4: oklch(0.6 0.16 20);
+  --chart-5: oklch(0.65 0.08 250);
+
+  --sidebar: oklch(0.19 0.02 290);
+  --sidebar-foreground: oklch(0.88 0.02 310);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.21 0.02 290);
+  --sidebar-accent: oklch(0.32 0.03 290);
+  --sidebar-accent-foreground: oklch(0.88 0.02 310);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #000;
+  --shadow-2xs: 0 1px 3px hsl(290 20% 5% / 0.1);
+  --shadow-xs: 0 1px 3px hsl(290 20% 5% / 0.15);
+  --shadow-sm: 0 2px 4px hsl(290 20% 5% / 0.18);
+  --shadow: 0 2px 6px hsl(290 20% 5% / 0.2);
+  --shadow-md: 0 3px 8px hsl(290 20% 5% / 0.22);
+  --shadow-lg: 0 4px 10px hsl(290 20% 5% / 0.25);
+  --shadow-xl: 0 6px 14px hsl(290 20% 5% / 0.28);
+  --shadow-2xl: 0 8px 18px hsl(290 20% 5% / 0.32);
+}
+
+.catppuccin-dark {
+  --background: oklch(0.24 0.02 260);
+  --foreground: oklch(0.9 0.01 280);
+
+  --card: oklch(0.22 0.02 260);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.22 0.02 260);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.7 0.15 310);
+  --primary-foreground: oklch(0.24 0.02 260);
+
+  --secondary: oklch(0.35 0.02 260);
+  --secondary-foreground: oklch(0.9 0.01 280);
+
+  --muted: oklch(0.3 0.02 260);
+  --muted-foreground: oklch(0.65 0.03 270);
+
+  --accent: oklch(0.68 0.1 240);
+  --accent-foreground: oklch(0.24 0.02 260);
+
+  --destructive: oklch(0.6 0.17 20);
+  --destructive-foreground: oklch(0.9 0.01 280);
+
+  --border: oklch(0.35 0.015 260);
+  --input: oklch(0.35 0.015 260);
+  --ring: oklch(0.7 0.15 310);
+
+  --chart-1: oklch(0.7 0.15 310);
+  --chart-2: oklch(0.68 0.1 240);
+  --chart-3: oklch(0.72 0.14 160);
+  --chart-4: oklch(0.76 0.12 80);
+  --chart-5: oklch(0.6 0.17 20);
+
+  --sidebar: oklch(0.2 0.02 260);
+  --sidebar-foreground: oklch(0.9 0.01 280);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.24 0.02 260);
+  --sidebar-accent: oklch(0.35 0.03 260);
+  --sidebar-accent-foreground: oklch(0.9 0.01 280);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #000;
+  --shadow-2xs: 0 1px 3px hsl(240 20% 3% / 0.1);
+  --shadow-xs: 0 1px 3px hsl(240 20% 3% / 0.15);
+  --shadow-sm: 0 2px 4px hsl(240 20% 3% / 0.18);
+  --shadow: 0 2px 6px hsl(240 20% 3% / 0.2);
+  --shadow-md: 0 3px 8px hsl(240 20% 3% / 0.22);
+  --shadow-lg: 0 4px 10px hsl(240 20% 3% / 0.25);
+  --shadow-xl: 0 6px 14px hsl(240 20% 3% / 0.28);
+  --shadow-2xl: 0 8px 18px hsl(240 20% 3% / 0.32);
+}
+
+/* Nord */
+.nord {
+  --background: oklch(0.25 0.02 240);
+  --foreground: oklch(0.9 0.01 230);
+
+  --card: oklch(0.28 0.02 240);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.28 0.02 240);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.68 0.06 240);
+  --primary-foreground: oklch(0.25 0.02 240);
+
+  --secondary: oklch(0.33 0.02 240);
+  --secondary-foreground: oklch(0.9 0.01 230);
+
+  --muted: oklch(0.3 0.02 240);
+  --muted-foreground: oklch(0.6 0.02 230);
+
+  --accent: oklch(0.72 0.08 200);
+  --accent-foreground: oklch(0.25 0.02 240);
+
+  --destructive: oklch(0.6 0.14 20);
+  --destructive-foreground: oklch(0.9 0.01 230);
+
+  --border: oklch(0.35 0.02 240);
+  --input: oklch(0.35 0.02 240);
+  --ring: oklch(0.68 0.06 240);
+
+  --chart-1: oklch(0.68 0.06 240);
+  --chart-2: oklch(0.72 0.08 200);
+  --chart-3: oklch(0.7 0.1 150);
+  --chart-4: oklch(0.75 0.1 80);
+  --chart-5: oklch(0.65 0.12 340);
+
+  --sidebar: oklch(0.22 0.02 240);
+  --sidebar-foreground: oklch(0.9 0.01 230);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.25 0.02 240);
+  --sidebar-accent: oklch(0.33 0.03 240);
+  --sidebar-accent-foreground: oklch(0.9 0.01 230);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #000;
+  --shadow-2xs: 0 1px 3px hsl(220 20% 5% / 0.1);
+  --shadow-xs: 0 1px 3px hsl(220 20% 5% / 0.15);
+  --shadow-sm: 0 2px 4px hsl(220 20% 5% / 0.18);
+  --shadow: 0 2px 6px hsl(220 20% 5% / 0.2);
+  --shadow-md: 0 3px 8px hsl(220 20% 5% / 0.22);
+  --shadow-lg: 0 4px 10px hsl(220 20% 5% / 0.25);
+  --shadow-xl: 0 6px 14px hsl(220 20% 5% / 0.28);
+  --shadow-2xl: 0 8px 18px hsl(220 20% 5% / 0.32);
+}
+
+/* Solarized Dark */
+.solarized {
+  --background: oklch(0.25 0.03 205);
+  --foreground: oklch(0.76 0.02 200);
+
+  --card: oklch(0.29 0.03 205);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.29 0.03 205);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.62 0.1 230);
+  --primary-foreground: oklch(0.25 0.03 205);
+
+  --secondary: oklch(0.35 0.03 205);
+  --secondary-foreground: oklch(0.76 0.02 200);
+
+  --muted: oklch(0.32 0.03 205);
+  --muted-foreground: oklch(0.56 0.02 200);
+
+  --accent: oklch(0.65 0.1 180);
+  --accent-foreground: oklch(0.25 0.03 205);
+
+  --destructive: oklch(0.55 0.15 25);
+  --destructive-foreground: oklch(0.76 0.02 200);
+
+  --border: oklch(0.38 0.03 205);
+  --input: oklch(0.38 0.03 205);
+  --ring: oklch(0.62 0.1 230);
+
+  --chart-1: oklch(0.62 0.1 230);
+  --chart-2: oklch(0.65 0.1 180);
+  --chart-3: oklch(0.65 0.1 140);
+  --chart-4: oklch(0.72 0.1 80);
+  --chart-5: oklch(0.58 0.14 30);
+
+  --sidebar: oklch(0.22 0.03 205);
+  --sidebar-foreground: oklch(0.76 0.02 200);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.25 0.03 205);
+  --sidebar-accent: oklch(0.33 0.04 205);
+  --sidebar-accent-foreground: oklch(0.76 0.02 200);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #000;
+  --shadow-2xs: 0 1px 3px hsl(192 30% 3% / 0.1);
+  --shadow-xs: 0 1px 3px hsl(192 30% 3% / 0.15);
+  --shadow-sm: 0 2px 4px hsl(192 30% 3% / 0.18);
+  --shadow: 0 2px 6px hsl(192 30% 3% / 0.2);
+  --shadow-md: 0 3px 8px hsl(192 30% 3% / 0.22);
+  --shadow-lg: 0 4px 10px hsl(192 30% 3% / 0.25);
+  --shadow-xl: 0 6px 14px hsl(192 30% 3% / 0.28);
+  --shadow-2xl: 0 8px 18px hsl(192 30% 3% / 0.32);
+}
+
+/* Solarized Light */
+.solarized-light {
+  --background: oklch(0.97 0.02 90);
+  --foreground: oklch(0.42 0.03 205);
+
+  --card: oklch(0.94 0.02 90);
+  --card-foreground: var(--foreground);
+  --popover: oklch(0.94 0.02 90);
+  --popover-foreground: var(--foreground);
+
+  --primary: oklch(0.62 0.1 230);
+  --primary-foreground: oklch(0.97 0.02 90);
+
+  --secondary: oklch(0.9 0.02 90);
+  --secondary-foreground: oklch(0.42 0.03 205);
+
+  --muted: oklch(0.92 0.015 90);
+  --muted-foreground: oklch(0.56 0.02 200);
+
+  --accent: oklch(0.65 0.1 180);
+  --accent-foreground: oklch(0.97 0.02 90);
+
+  --destructive: oklch(0.55 0.15 25);
+  --destructive-foreground: oklch(0.97 0.02 90);
+
+  --border: oklch(0.85 0.02 90);
+  --input: oklch(0.85 0.02 90);
+  --ring: oklch(0.62 0.1 230);
+
+  --chart-1: oklch(0.62 0.1 230);
+  --chart-2: oklch(0.65 0.1 180);
+  --chart-3: oklch(0.65 0.1 140);
+  --chart-4: oklch(0.72 0.1 80);
+  --chart-5: oklch(0.58 0.14 30);
+
+  --sidebar: oklch(0.94 0.02 90);
+  --sidebar-foreground: oklch(0.42 0.03 205);
+  --sidebar-primary: var(--primary);
+  --sidebar-primary-foreground: oklch(0.97 0.02 90);
+  --sidebar-accent: oklch(0.88 0.02 90);
+  --sidebar-accent-foreground: oklch(0.42 0.03 205);
+  --sidebar-border: var(--border);
+  --sidebar-ring: var(--ring);
+
+  --font-sans: Plus Jakarta Sans, sans-serif;
+  --font-serif: Lora, serif;
+  --font-mono: Roboto Mono, monospace;
+
+  --radius: 1.25rem;
+  --shadow-color: #93a1a1;
+  --shadow-2xs: 0 1px 3px hsl(44 10% 50% / 0.08);
+  --shadow-xs: 0 1px 3px hsl(44 10% 50% / 0.1);
+  --shadow-sm: 0 2px 4px hsl(44 10% 50% / 0.12);
+  --shadow: 0 2px 6px hsl(44 10% 50% / 0.15);
+  --shadow-md: 0 3px 8px hsl(44 10% 50% / 0.18);
+  --shadow-lg: 0 4px 10px hsl(44 10% 50% / 0.2);
+  --shadow-xl: 0 6px 14px hsl(44 10% 50% / 0.22);
+  --shadow-2xl: 0 8px 18px hsl(44 10% 50% / 0.25);
 }
 
 @theme inline {


### PR DESCRIPTION
This pull request introduces a new multi-theme system to the app, replacing the previous light/dark toggle with a more flexible and visually rich theme picker. It also adds infrastructure for displaying available buy order shares for companies, and includes some improvements and fixes to UI component code. The most important changes are grouped below:

**Theme System Overhaul**

* Added a new `themes` array in `src/lib/server/theme.ts` supporting multiple themes, each with metadata like label, dark mode flag, and color swatch. Also introduced the `ThemeId` type.
* Replaced the old light/dark toggle in `src/components/theme-toggle.tsx` with a popover-based theme picker UI, allowing users to select from all available themes.
* Updated `ThemeProvider` and all theme-related types/components to use `ThemeId` instead of the previous `T` union, and added `getThemeClasses` utility for correct class assignment. [[1]](diffhunk://#diff-41578ab9c9e0cf8349d184c064ea7f0fff8f79b6bc9f5cc118305d1912e413dfL4-R15) [[2]](diffhunk://#diff-461d02a8b6beb09b75dd36782176c6ddef00cca36db72376541c0043f2d8e06fR77-R84) [[3]](diffhunk://#diff-f8e27e284036127530471f17f7a5bdb7ac94c6fbfec767ba3a28113c09eeeb99L20-R20) [[4]](diffhunk://#diff-f8e27e284036127530471f17f7a5bdb7ac94c6fbfec767ba3a28113c09eeeb99L92-R92)

**UI Component Improvements**

* Added a new popover component in `src/components/ui/popover.tsx` for consistent popover UI, used by the new theme picker.
* Refactored `src/components/ui/select.tsx` for improved code style, fixed some className issues, and updated attribute syntax for better Radix compatibility. [[1]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL1-R22) [[2]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL31-R39) [[3]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL48-R48) [[4]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL63-R66) [[5]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL77-R85) [[6]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL98-R98) [[7]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL110-R111) [[8]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL125-R125) [[9]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL138-R138) [[10]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL150-R156) [[11]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL168-R174) [[12]](diffhunk://#diff-8c28296e52472293865b866f53b4d74262fc069d500d0a3b9505ac139b4c700eL188-R188)

**Stocks/Companies Data**

* Added calculation and exposure of `buyOrderShares` to company data, representing open/partial buy orders, in `src/lib/server/stocks.ts`. [[1]](diffhunk://#diff-799757152aae017df6fa29110411f5667d70f69eaeeafee719a8a40684341b8cR128-R145) [[2]](diffhunk://#diff-799757152aae017df6fa29110411f5667d70f69eaeeafee719a8a40684341b8cR164)