### PR TITLE
fix(elections): change line type to remove graph overshoot

### DIFF
--- a/src/routes/elections/president.tsx
+++ b/src/routes/elections/president.tsx
@@ -502,7 +502,7 @@ function CampaignGraphs({
                   {candidates.map((candidate) => (
                     <Line
                       key={candidate.id}
-                      type="natural"
+                      type="monotone"
                       dataKey={candidate.username}
                       stroke={candidateColors[candidate.id]}
                       strokeWidth={3}
@@ -635,7 +635,7 @@ function CampaignGraphs({
                   {candidates.map((candidate) => (
                     <Line
                       key={candidate.id}
-                      type="natural"
+                      type="monotone"
                       dataKey={candidate.username}
                       stroke={candidateColors[candidate.id]}
                       strokeWidth={3}

--- a/src/routes/elections/senate.tsx
+++ b/src/routes/elections/senate.tsx
@@ -507,7 +507,7 @@ function CampaignGraphs({
                   {candidates.map((candidate) => (
                     <Line
                       key={candidate.id}
-                      type="natural"
+                      type="monotone"
                       dataKey={candidate.username}
                       stroke={candidateColors[candidate.id]}
                       strokeWidth={3}
@@ -640,7 +640,7 @@ function CampaignGraphs({
                   {candidates.map((candidate) => (
                     <Line
                       key={candidate.id}
-                      type="natural"
+                      type="monotone"
                       dataKey={candidate.username}
                       stroke={candidateColors[candidate.id]}
                       strokeWidth={3}


### PR DESCRIPTION
E.g. this graphs negative overshoot
<img width="645" height="290" alt="image" src="https://github.com/user-attachments/assets/b486465f-c963-4980-884c-edb99410be63" />
